### PR TITLE
Fix namespace handling

### DIFF
--- a/nomad/table_nomad_deployment.go
+++ b/nomad/table_nomad_deployment.go
@@ -170,7 +170,16 @@ func listDeployments(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 
 func getDeployment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
-	id := d.EqualsQualString("id")
+	var id string
+	var namespace string
+	if h.Item != nil {
+		stub := h.Item.(*api.Deployment)
+		id = stub.ID
+		namespace = stub.Namespace
+	} else {
+		id = d.EqualsQualString("id")
+		namespace = d.EqualsQualString("namespace")
+	}
 
 	// check if id is empty
 	if id == "" {
@@ -180,11 +189,13 @@ func getDeployment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	// Create client
 	client, err := getClient(ctx, d)
 	if err != nil {
-		logger.Error("nomad_node.getDeployment", "connection_error", err)
+		logger.Error("nomad_deployment.getDeployment", "connection_error", err)
 		return nil, err
 	}
 
-	deployment, _, err := client.Deployments().Info(id, &api.QueryOptions{})
+	deployment, _, err := client.Deployments().Info(id, &api.QueryOptions{
+		Namespace: namespace,
+	})
 	if err != nil {
 		logger.Error("nomad_node.getDeployment", "api_error", err)
 		return nil, err

--- a/nomad/table_nomad_job.go
+++ b/nomad/table_nomad_job.go
@@ -308,10 +308,14 @@ func listJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 func getJob(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	var id string
+	var namespace string
 	if h.Item != nil {
-		id = h.Item.(*api.JobListStub).ID
+		stub := h.Item.(*api.JobListStub)
+		id = stub.ID
+		namespace = stub.Namespace
 	} else {
 		id = d.EqualsQualString("id")
+		namespace = d.EqualsQualString("namespace")
 	}
 
 	// check if id is empty
@@ -322,13 +326,15 @@ func getJob(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (in
 	// Create client
 	client, err := getClient(ctx, d)
 	if err != nil {
-		logger.Error("nomad_node.getJob", "connection_error", err)
+		logger.Error("nomad_job.getJob", "connection_error", err)
 		return nil, err
 	}
 
-	job, _, err := client.Jobs().Info(id, &api.QueryOptions{})
+	job, _, err := client.Jobs().Info(id, &api.QueryOptions{
+		Namespace: namespace,
+	})
 	if err != nil {
-		logger.Error("nomad_node.getJob", "api_error", err)
+		logger.Error("nomad_job.getJob", "api_error", err)
 		return nil, err
 	}
 

--- a/nomad/table_nomad_volume.go
+++ b/nomad/table_nomad_volume.go
@@ -286,10 +286,14 @@ func listVolumes(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 func getVolume(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	var id string
+	var namespace string
 	if h.Item != nil {
-		id = h.Item.(*api.CSIVolumeListStub).ID
+		stub := h.Item.(*api.CSIVolumeListStub)
+		id = stub.ID
+		namespace = stub.Namespace
 	} else {
 		id = d.EqualsQualString("id")
+		namespace = d.EqualsQualString("namespace")
 	}
 
 	// check if id is empty
@@ -300,11 +304,13 @@ func getVolume(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 	// Create client
 	client, err := getClient(ctx, d)
 	if err != nil {
-		logger.Error("nomad_node.getVolume", "connection_error", err)
+		logger.Error("nomad_volume.getVolume", "connection_error", err)
 		return nil, err
 	}
 
-	volume, _, err := client.CSIVolumes().Info(id, &api.QueryOptions{})
+	volume, _, err := client.CSIVolumes().Info(id, &api.QueryOptions{
+		Namespace: namespace,
+	})
 	if err != nil {
 		logger.Error("nomad_node.getVolume", "api_error", err)
 		return nil, err


### PR DESCRIPTION
using `namespace = '*"` prevented job details to been shown.


(to be honest it's been a while, that I created this patch, I'm not 100% sure anymore which query made my initial problems)

# Example query results

```
select
  job.status as job_status,
  job.namespace,
  job.type as job_type,
  job.name as job_name,
  task_group.value ->> 'Name' as task_group_name,
  task.value ->> 'Name' as task_name,
  (task_group.value ->> 'Count')::int as allocation_count,
  task.value -> 'Config' ->> 'image' as image
from
  nomad_job as job,
  jsonb_array_elements(job.task_groups) as task_group,
  jsonb_array_elements(task_group.value -> 'Tasks') as task
where
  task.value -> 'Config' ->> 'privileged' = 'true'
```
